### PR TITLE
adding on-load delay

### DIFF
--- a/accounts.html
+++ b/accounts.html
@@ -83,8 +83,19 @@
       }
     };
 
-    // Start the application
-    app();
+    /** 
+     * Check if notifications were loaded to the page 
+     * before starting the app. If not, add a 100ms delay
+     * so jQuery can load them.
+     * 
+     * @dev: important on first load / no cache.
+     */
+    if (el("#notifications").childElementCount === 0) {
+      setTimeout(function () { app() }, 100);
+    }
+    else {
+      app()
+    }
   </script>
 </body>
 

--- a/simple-storage.html
+++ b/simple-storage.html
@@ -133,8 +133,19 @@
       }
     };
 
-    // Start the application
-    app();
+    /** 
+     * Check if notifications were loaded to the page 
+     * before starting the app. If not, add a 100ms delay
+     * so jQuery can load them.
+     * 
+     * @dev: important on first load / no cache.
+     */
+    if (el("#notifications").childElementCount === 0) {
+      setTimeout(function () { app() }, 100);
+    }
+    else {
+      app()
+    }
   </script>
 </body>
 


### PR DESCRIPTION
This PR fixes an on-load error while using host services or not allowing cache on sites.
Due to jQuery, notifications sometimes did not load before the application accessed their properties.

I added a small query to the main files, in case the notifications are not loaded before starting the app. A delay seems like the only solution here since: 

- sequential execution of external scripts is not possible in plain HTML (defer/async just calls in order),
- utils.js has to stay without any dependencies to other files, 
- external checks should not bloat up the app() functions, and
- JS's window.onload would fully remain on the site's cache