### PR TITLE
Fix no-extension detection

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -7,32 +7,31 @@ async function connectWeb3() {
     ) {
       
       // Check if browser extension is installed
-      try {
   
-        // Get account
-        if (window.ethereum) {
+      // Get account
+      if (window.ethereum) {
   
-          // Request account
-          let account = await ethereum.request({ method: "eth_accounts" });
+        // Request account
+        let account = await ethereum.request({ method: "eth_accounts" });
   
-          // If no account was found
-          if (!account.length) {
+        // If no account was found
+        if (!account.length) {
   
-            // Show login button 
-            el("#login").style.display = "block";
-            return false;
-          } 
-          else {
-            return true;
-          }
+          // Show login button 
+          el("#login").style.display = "block";
+          return false;
+        } 
+        else {
+          return true;
         }
+      }
       
       // Provider not set or invalid
-      } catch (e) {
-  
-        // Show install extension notification
-        el("#install").style.display = "block";
-        return false;
+      else{
+
+      // Show install extension notification
+      el("#install").style.display = "block";
+      return false;
       }
     }
     


### PR DESCRIPTION
This PR removes a try-catch statement that could not be triggered when not having an Ethereum extension installed. The new version uses a simple `else` statement. 