### PR TITLE
Fix no-extension notification

### DIFF
--- a/notifications.html
+++ b/notifications.html
@@ -1,5 +1,5 @@
 <!-- Notifications -->
-<p class="note" style="display: block;">If you have MetaMask AND Universal Profile Browser Extension installed, please
+<p class="note" id="singular" style="display: block;">If you have MetaMask AND Universal Profile Browser Extension installed, please
     disable one of them! See these guides for
     <a href="https://support.google.com/chrome_webstore/answer/2664769?hl=en" target="_blank">Chrome</a> and
     <a href="https://support.mozilla.org/en-US/kb/disable-or-remove-add-ons#w_disabling-and-removing-extensions"

--- a/utils.js
+++ b/utils.js
@@ -7,32 +7,32 @@ async function connectWeb3() {
     ) {
       
       // Check if browser extension is installed
-      try {
   
-        // Get account
-        if (window.ethereum) {
+      // Get account
+      if (window.ethereum) {
   
-          // Request account
-          let account = await ethereum.request({ method: "eth_accounts" });
+        // Request account
+        let account = await ethereum.request({ method: "eth_accounts" });
   
-          // If no account was found
-          if (!account.length) {
+        // If no account was found
+        if (!account.length) {
   
-            // Show login button 
-            el("#login").style.display = "block";
-            return false;
-          } 
-          else {
-            return true;
-          }
+          // Show login button 
+          el("#login").style.display = "block";
+          return false;
+        } 
+        else {
+          return true;
         }
+      }
       
       // Provider not set or invalid
-      } catch (e) {
-  
-        // Show install extension notification
-        el("#install").style.display = "block";
-        return false;
+      else{
+
+      // Show install extension notification
+      el("#install").style.display = "block";
+      el("#singular").style.display = "none";
+      return false;
       }
     }
     
@@ -41,6 +41,7 @@ async function connectWeb3() {
   
       // Show unsupported browser notification
       el("#browser").style.display = "block";
+      el("#singular").style.display = "none";
       return false;
     }
 }


### PR DESCRIPTION
This PR removes a `try-catch` statement that could not be triggered when not having an Ethereum extension installed. The new version uses a simple `else` statement.

The "only activate one extension" notification also get hidden, if the browser extension is not installed, or when using an unsupported browser